### PR TITLE
Use @tailwindcss/typography for About page too

### DIFF
--- a/src/_includes/default.liquid
+++ b/src/_includes/default.liquid
@@ -8,4 +8,6 @@ layout: main
   
 {% include "nav.liquid" %}
 
-{{ content }}
+<div class="prose dark:prose-invert hover:prose-a:text-blue-500">
+  {{ content }}
+</div>


### PR DESCRIPTION
class "prose" comes from https://tailwindcss.com/docs/plugins#typography

And that's what's used in post bodies.

When we look at the table styling preview as documented by those developers

  https://play.tailwindcss.com/uj1vGACRJA?layout=preview

We see that this is the way they want tables to look.

So let's also use that for pages other than post pages for consistency.

Fixes #18